### PR TITLE
Use reference to const QString instead QStringView

### DIFF
--- a/spellcheck/spellcheck_types.h
+++ b/spellcheck/spellcheck_types.h
@@ -8,3 +8,7 @@
 
 using MisspelledWord = std::pair<int, int>;
 using MisspelledWords = std::vector<MisspelledWord>;
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+using QStringView = const QString&;
+#endif


### PR DESCRIPTION
This fixes build Telegram Desktop against Qt 5.9 and earlier.