### PR TITLE
Don't try to load all dictionaries with enchant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,4 +44,6 @@ if (LINUX)
 
     pkg_search_module(ENCHANT REQUIRED enchant-2 enchant)
     target_include_directories(lib_spellcheck PRIVATE ${ENCHANT_INCLUDE_DIRS})
+
+    target_link_libraries(lib_spellcheck PUBLIC desktop-app::external_sonnet)
 endif()


### PR DESCRIPTION
On debian enchant compiled without hspell, but on others with hspell. Because the current algorithm adds all dictionaries (which is incorrect), on non-debian distros, when enchant tries to check a word with hspell - it getitng an error.
Fixes telegramdesktop/tdesktop#6907, telegramdesktop/tdesktop#6983 (and possible duplicate telegramdesktop/tdesktop#6922)