### PR TITLE
Fix stack-use-after-scope

### DIFF
--- a/spellcheck/spelling_highlighter.cpp
+++ b/spellcheck/spelling_highlighter.cpp
@@ -421,7 +421,8 @@ bool SpellingHighlighter::isSkippableWord(int position, int length) {
 	if (hasUnspellcheckableTag(position, length)) {
 		return true;
 	}
-	const auto ref = documentText().midRef(position, length);
+	const auto text = documentText();
+	const auto ref = text.midRef(position, length);
 	if (ref.isNull()) {
 		return true;
 	}


### PR DESCRIPTION
This fixes a bug caught by ASAN. The `documentText` method returns a temporary `QString` which goes out of scope at the end of line 424. This means that, on line 425, `ref` references stack memory that has gone out of scope. Here's the ASAN output:

```
==1587==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7ffe3b32f4f0 at pc 0x000005aea950 bp 0x7ffe3b32f460 sp 0x7ffe3b32f450
READ of size 8 at 0x7ffe3b32f4f0 thread T0
    #0 0x5aea94f in QString::isNull() const /usr/local/desktop-app/Qt-5.12.5/include/QtCore/qstring.h:822
    #1 0x9691bfd in QStringRef::isNull() const /usr/local/desktop-app/Qt-5.12.5/include/QtCore/qstring.h:1555
    #2 0x966d7ad in Spellchecker::SpellingHighlighter::isSkippableWord(int, int) /home/build/tdesktop/Telegram/lib_spellcheck/spellcheck/spelling_highlighter.cpp:425
```