### PR TITLE
Prepend PkgConfig variables with DESKTOP_APP_ 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,6 @@ PRIVATE
 if (LINUX AND use_enchant)
     find_package(PkgConfig REQUIRED)
 
-    pkg_search_module(ENCHANT REQUIRED enchant-2 enchant)
-    target_include_directories(lib_spellcheck SYSTEM PRIVATE ${ENCHANT_INCLUDE_DIRS})
+    pkg_search_module(DESKTOP_APP_ENCHANT REQUIRED enchant-2 enchant)
+    target_include_directories(lib_spellcheck SYSTEM PRIVATE ${DESKTOP_APP_ENCHANT_INCLUDE_DIRS})
 endif()

--- a/spellcheck/third_party/language_cld3.cpp
+++ b/spellcheck/third_party/language_cld3.cpp
@@ -6,7 +6,7 @@
 //
 #include "spellcheck/third_party/language_cld3.h"
 
-#include "nnet_language_identifier.h"
+#include <nnet_language_identifier.h>
 
 namespace Platform::Language {
 


### PR DESCRIPTION
To avoid clashes with cache variables set by third party cmake modules