### PR TITLE
enchant: allow toggling individual dictionaries

### DIFF
--- a/spellcheck/platform/mac/spellcheck_mac.mm
+++ b/spellcheck/platform/mac/spellcheck_mac.mm
@@ -57,6 +57,11 @@ std::vector<QString> ActiveLanguages() {
 	return SystemLanguages();
 }
 
+std::vector<QString> AvailableLanguages() {
+	// SupportsToggleDictionaries() returns false; not supported.
+	return {};
+}
+
 bool CheckSpelling(const QString &word) {
 	if (@available(macOS 10.14, *)) {
 		return [SharedSpellChecker()
@@ -176,8 +181,13 @@ bool IsSystemSpellchecker() {
 	return true;
 }
 
+bool SupportsToggleDictionaries() {
+	// Apparently not fusible; can only be toggled in system settings.
+	return false;
+}
+
 void UpdateLanguages(std::vector<int> languages) {
-	::Spellchecker::UpdateSupportedScripts(SystemLanguages());
+	// SupportsToggleDictionaries() returns false; not supported.
 }
 
 } // namespace Platform::Spellchecker

--- a/spellcheck/platform/platform_spellcheck.h
+++ b/spellcheck/platform/platform_spellcheck.h
@@ -14,11 +14,13 @@ namespace Platform::Spellchecker {
 constexpr auto kMaxSuggestions = 5;
 
 [[nodiscard]] bool IsSystemSpellchecker();
+[[nodiscard]] bool SupportsToggleDictionaries();
 [[nodiscard]] bool CheckSpelling(const QString &wordToCheck);
 [[nodiscard]] bool IsWordInDictionary(const QString &wordToCheck);
 
 void Init();
 std::vector<QString> ActiveLanguages();
+std::vector<QString> AvailableLanguages();
 void FillSuggestionList(
 	const QString &wrongWord,
 	std::vector<QString> *optionalSuggestions);

--- a/spellcheck/platform/win/spellcheck_win.cpp
+++ b/spellcheck/platform/win/spellcheck_win.cpp
@@ -64,6 +64,7 @@ public:
 		MisspelledWords *misspelledWordRanges,
 		int offset);
 	[[nodiscard]] std::vector<QString> systemLanguages();
+	[[nodiscard]] std::vector<QString> availableLanguages();
 	void chunkedCheckSpellingText(
 		QStringView textView,
 		MisspelledWords *misspelledWords);
@@ -275,6 +276,11 @@ std::vector<QString> WindowsSpellChecker::systemLanguages() {
 	return ranges::views::keys(_spellcheckerMap) | ranges::to_vector;
 }
 
+std::vector<QString> WindowsSpellChecker::availableLanguages() {
+	// SupportsToggleDictionaries() returns false; not implemented.
+	return {};
+}
+
 void WindowsSpellChecker::chunkedCheckSpellingText(
 		QStringView textView,
 		MisspelledWords *misspelledWords) {
@@ -338,11 +344,22 @@ bool IsSystemSpellchecker() {
 	return IsWindows8OrGreater();
 }
 
+bool SupportsToggleDictionaries() {
+	// Not implemented for Windows.
+	// Feasible with native spellchecker, unknown with hunspell.
+	return false;
+}
+
 std::vector<QString> ActiveLanguages() {
 	if (IsSystemSpellchecker()) {
 		return SharedSpellChecker().systemLanguages();
 	}
 	return ThirdParty::ActiveLanguages();
+}
+
+std::vector<QString> AvailableLanguages() {
+	// SupportsToggleDictionaries() returns false; not implemented.
+	return {};
 }
 
 bool CheckSpelling(const QString &wordToCheck) {

--- a/spellcheck/spellcheck_utils.cpp
+++ b/spellcheck/spellcheck_utils.cpp
@@ -318,4 +318,23 @@ QLocale LocaleFromLangId(int langId) {
 	return QLocale(lang, country);
 }
 
+int LangIdFromLocale(const QString &locale) {
+	const auto qlocale = QLocale(locale);
+	const auto lang = qlocale.language();
+	const auto country = qlocale.country();
+
+	if (country != QLocale::AnyCountry) {
+		constexpr QLocale::Language kLangsForLWC[] = { QLocale::English, QLocale::Portuguese };
+		constexpr QLocale::Country kDefaultCountries[] = { QLocale::UnitedStates, QLocale::Brazil };
+
+		if (ranges::contains(kLangsForLWC, lang)
+			&& ranges::contains(kDefaultCountries, country)) {
+			return int(lang);
+		}
+
+		return (int(lang) * kFactor) + int(country);
+	}
+	return int(lang);
+}
+
 } // namespace Spellchecker

--- a/spellcheck/spellcheck_utils.h
+++ b/spellcheck/spellcheck_utils.h
@@ -28,6 +28,7 @@ MisspelledWords RangesFromText(
 bool CheckSkipAndSpell(const QString &word);
 
 QLocale LocaleFromLangId(int langId);
+int LangIdFromLocale(const QString &locale);
 
 void UpdateSupportedScripts(std::vector<QString> languages);
 rpl::producer<> SupportedScriptsChanged();

--- a/spellcheck/spelling_highlighter.cpp
+++ b/spellcheck/spelling_highlighter.cpp
@@ -824,8 +824,7 @@ void SpellingHighlighter::fillSpellcheckerMenu(
 		not_null<QMenu*> menu,
 		QTextCursor cursorForPosition,
 		FnMut<void(int firstSuggestionIndex)> show) {
-	const auto customItem = !Platform::Spellchecker::IsSystemSpellchecker()
-		&& _customContextMenuItem.has_value();
+	const auto customItem = _customContextMenuItem.has_value();
 
 	cursorForPosition.select(QTextCursor::WordUnderCursor);
 

--- a/spellcheck/third_party/spellcheck_hunspell.cpp
+++ b/spellcheck/third_party/spellcheck_hunspell.cpp
@@ -52,8 +52,18 @@ bool IsSystemSpellchecker() {
 	return false;
 }
 
+bool SupportsToggleDictionaries() {
+	return false;
+}
+
+std::vector<QString> AvailableLanguages() {
+	// SupportsToggleDictionaries() returns false; not supported.
+	// Maybe we can enumerate $WORKINGDIR}/$LANG/$LANG.{aff,dic}?
+	return {};
+}
+
 void UpdateLanguages(std::vector<int> languages) {
-	ThirdParty::UpdateLanguages(languages);
+	// SupportsToggleDictionaries() returns false; not supported.
 }
 
 } // namespace Platform::Spellchecker


### PR DESCRIPTION
Allow disabling and enabling individual dictionaries with the Enchant/Hunspell backend.

This is mostly relevant in shared systems (where different users want to enable different sets of languages) or on distributions which install an exorbitant amount of dictionaries by default.