### PR TITLE
Take the word under the cursor from the shared word rule.

### DIFF
--- a/spellcheck/spellcheck_utils.cpp
+++ b/spellcheck/spellcheck_utils.cpp
@@ -6,6 +6,7 @@
 //
 #include "spellcheck/spellcheck_utils.h"
 #include "spellcheck/platform/platform_spellcheck.h"
+#include "ui/text/text.h"
 
 #include <QtCore/QStringList>
 #include <QTextBoundaryFinder>
@@ -329,6 +330,44 @@ MisspelledWords RangesFromText(
 		}
 	}
 	return ranges;
+}
+
+MisspelledWord WordAtPosition(Fn<QChar(int)> at, int length, int position) {
+	if (!length) {
+		return { 0, 0 };
+	}
+	position = std::clamp(position, 0, length);
+	const auto separator = [&](int index) {
+		return Ui::Text::IsWordSeparator(at, length, index);
+	};
+
+	// Standing inside a word means the whole of that word.
+	if (position < length && !separator(position)) {
+		auto from = position;
+		while (from > 0 && !separator(from - 1)) {
+			--from;
+		}
+		auto till = position;
+		while (till < length && !separator(till)) {
+			++till;
+		}
+		return { from, till - from };
+	}
+
+	// Standing between words means the one on the left, the way
+	// QTextCursor::WordUnderCursor answers.
+	auto till = position;
+	while (till > 0 && separator(till - 1)) {
+		--till;
+	}
+	if (!till) {
+		return { position, 0 };
+	}
+	auto from = till;
+	while (from > 0 && !separator(from - 1)) {
+		--from;
+	}
+	return { from, till - from };
 }
 
 QString NormalizeApostrophes(const QString &word) {

--- a/spellcheck/spellcheck_utils.h
+++ b/spellcheck/spellcheck_utils.h
@@ -26,6 +26,16 @@ MisspelledWords RangesFromText(
 	const QString &text,
 	Fn<bool(const QString &word)> filterCallback);
 
+// The word the position is inside of, or the one to the left of it when the
+// position is between two words - which is what QTextCursor::WordUnderCursor
+// answers. Words are told apart by Ui::Text::IsWordSeparator(), so that a word
+// with an apostrophe in it stays one word here as well. The text is read a
+// character at a time, so that a block of a document needs no copy.
+[[nodiscard]] MisspelledWord WordAtPosition(
+	Fn<QChar(int)> at,
+	int length,
+	int position);
+
 // For Linux and macOS, which use RangesFromText.
 bool CheckSkipAndSpell(const QString &word);
 

--- a/spellcheck/spelling_highlighter.cpp
+++ b/spellcheck/spelling_highlighter.cpp
@@ -611,9 +611,15 @@ bool SpellingHighlighter::hasUnspellcheckableTag(int begin, int length) {
 }
 
 MisspelledWord SpellingHighlighter::getWordUnderPosition(int position) {
-	_cursor.setPosition(std::clamp(position, 0, std::max(0, size() - 1)));
-	_cursor.select(QTextCursor::WordUnderCursor);
-	return RangeFromCursorSelection(_cursor);
+	const auto clamped = std::clamp(position, 0, std::max(0, size() - 1));
+	const auto block = findBlock(clamped);
+	const auto shift = block.position();
+	const auto raw = document();
+	const auto word = WordAtPosition(
+		[raw, shift](int index) { return raw->characterAt(shift + index); },
+		block.length() - 1,
+		clamped - shift);
+	return { word.first + shift, word.second };
 }
 
 void SpellingHighlighter::highlightBlock(const QString &text) {
@@ -825,7 +831,13 @@ void SpellingHighlighter::fillSpellcheckerMenu(
 	const auto customItem = !Platform::Spellchecker::IsSystemSpellchecker()
 		&& _customContextMenuItem.has_value();
 
-	cursorForPosition.select(QTextCursor::WordUnderCursor);
+	{
+		const auto word = getWordUnderPosition(cursorForPosition.position());
+		cursorForPosition.setPosition(word.first);
+		cursorForPosition.setPosition(
+			word.first + word.second,
+			QTextCursor::KeepAnchor);
+	}
 
 	// There is no reason to call async work if the word is skippable.
 	const auto skippable = [&] {


### PR DESCRIPTION
The word *under the cursor* was taken with
`QTextCursor::select(QTextCursor::WordUnderCursor)` in two places - when a range
is re-checked after an edit, and when the context menu is filled. That path goes
through `QTextEngine::atWordSeparator()`, a hardcoded list of ASCII punctuation
that has the apostrophe in it, so `don't` was cut down to `don`: the suggestions
were offered for a piece of the word, and "add to dictionary" added that piece.
One of the Qt patches of the official builds is what makes it behave; on an
unpatched Qt the menu and the underline disagree - `donn't` shows it.

`WordAtPosition()` now answers it with `Ui::Text::IsWordSeparator()`, which knows
the same rule the patch teaches Qt: an apostrophe is a separator only when it is
doubled or when it stands at the edge of a word. The whole module then agrees
about what a word is, without the patch.

`RangesFromText()` is left alone: splitting a whole text needs the Unicode word
boundaries, which a list of separators cannot replace for the scripts that do
not put spaces between words.

The text is read a character at a time, through `QTextDocument::characterAt()`,
so a block is not copied for every question. Measured on the same machine with
the flags of the release build (`-O3 -flto`, static Qt), per call:

| block | `WordUnderCursor` | this |
|---|---|---|
| 128 | 558 ns | 398 ns |
| 512 | 548 ns | 396 ns |
| 4096 | 536 ns | 402 ns |
| 8192 | 534 ns | 404 ns |
| 16384 | 563 ns | 400 ns |

It also keeps the convention of `WordUnderCursor` - when the position is between
two words, the one on the left is answered - because the caller compensates for
it (`isPosNotInWord` in `contentsChange()`). Verified against it on every
position of a set of samples.

Needs desktop-app/lib_ui#352.
