### PR TITLE
Mark misspelled words with a property, not with an underline style.

### DIFF
--- a/spellcheck/spelling_highlighter.cpp
+++ b/spellcheck/spelling_highlighter.cpp
@@ -178,8 +178,10 @@ SpellingHighlighter::SpellingHighlighter(
 
 	_cachedRanges = MisspelledWords();
 
-	// Use the patched SpellCheckUnderline style.
-	_misspelledFormat.setUnderlineStyle(QTextCharFormat::SpellCheckUnderline);
+	// Marked for the field to draw the mark itself: what Qt draws for
+	// SpellCheckUnderline is a plain wave, and the mark of Chrome that is
+	// wanted here used to be a patch of Qt.
+	_misspelledFormat.setProperty(Ui::InputField::kMisspelledProperty, true);
 	style::PaletteChanged(
 	) | rpl::on_next([=] {
 		updatePalette();


### PR DESCRIPTION
The mark under a misspelled word is drawn by the field now, so the format the
highlighter applies carries a property instead of asking Qt for
`QTextCharFormat::SpellCheckUnderline`. The colour stays where it was, in
`underlineColor()`, and the field reads it from there.

Goes together with desktop-app/lib_ui#346, which adds the property and the
drawing; without it the mark is not drawn at all.
